### PR TITLE
Add generic samples for null-accepting properties

### DIFF
--- a/proposals/csharp-8.0/nullable-samples.md
+++ b/proposals/csharp-8.0/nullable-samples.md
@@ -1,9 +1,9 @@
-Nullable Scenarios
+# Nullable Scenarios
 ---
 
-# Properties
+## Properties
 
-## Write null but read non-null
+### Write null but read non-null
 *My property wants to accept potentially `null` values during a `set` but will 
 always produce a non-null value on `get`.*
 
@@ -31,9 +31,64 @@ class Widget {
 
 Generic:
 
+*My property accepts null even if the substituted type is non-nullable.*
+
 ``` csharp
+using System;
+using System.Diagnostics.CodeAnalysis;
+
 class Box<T> {
     T _value;
+    Box(T value) {
+        _value = value;
+    }
+
+    [AllowNull]
+    T Value {
+       get => _value;
+        set {
+            if (value != null) {
+               _value = value;
+            }
+        }
+    }
+
+    static void TestConstrained<U>(Box<U> box) where U : class {
+        box.Value = null; // ok
+        Console.WriteLine(box.Value.ToString()); // ok
+
+        if (box.Value == null) {
+            Console.WriteLine(box.Value.ToString()); // warning
+        }
+    }
+
+    static void TestUnconstrained<U>(Box<U> box, U value) {
+       box.Value = default(U); // 'default(U)' always produces a warning when U could be a non-nullable reference type
+        Console.WriteLine(box.Value.ToString()); // warning
+
+        box.Value = value; // ok
+        Console.WriteLine(box.Value.ToString()); // warning
+
+        if (box.Value != null) {
+           Console.WriteLine(box.Value.ToString()); // ok
+        }
+    }
+}
+```
+
+Generic:
+
+*My property accepts null but will never return null, because its substituted type will not be nullable*
+
+``` csharp
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class Box<T> where T : notnull {
+    T _value;
+    Box(T value) {
+        _value = value;
+    }
 
     [AllowNull]
     T Value {
@@ -45,17 +100,72 @@ class Box<T> {
         }
     }
 
-    static void TestConstrained<U>(Box<U> box) where U : class?
-    {
+    static void TestConstrained<U>(Box<U> box) where U : class {
         box.Value = null; // ok
         Console.WriteLine(box.Value.ToString()); // ok
+
+        if (box.Value == null) {
+            Console.WriteLine(box.Value.ToString()); // warning
+        }
     }
 
-    static void TestUnconstrained<U>(Box<U> box, U value)
-    {
-        box.Value = default(U); // warn on default of unconstraind type param
+    static void TestUnconstrained<U>(Box<U> box, U value) { 
+        box.Value = default(U); // 'default(U)' always produces a warning when U could be a non-nullable reference type
+        Console.WriteLine(box.Value.ToString()); // ok
+
         box.Value = value; // ok
         Console.WriteLine(box.Value.ToString()); // ok
+
+       if (box.Value == null) {
+            Console.WriteLine(box.Value.ToString()); // warning
+        }
+    }
+}
+```
+
+Generic:
+
+*My property accepts null, and will never return null, even if its substituted type is nullable.*
+
+``` csharp
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class Box<T> {
+    [NotNull] T _value;
+    Box([DisallowNull] T value) {
+        _value = value;
+    }
+
+    [AllowNull, NotNull]
+    T Value {
+        get => _value;
+        set {
+            if (value != null) {
+                _value = value;
+            }
+        }
+    }
+
+    static void TestConstrained<U>(Box<U> box) where U : class? {
+        box.Value = null; // ok
+        Console.WriteLine(box.Value.ToString()); // ok
+
+        if (box.Value == null) {
+            Console.WriteLine(box.Value.ToString()); // warning
+        }
+    }
+
+    static void TestUnconstrained<U>(Box<U> box, U value) { 
+        box.Value = default(U); // 'default(U)' always produces a warning when U could be a non-nullable reference type
+        Console.WriteLine(box.Value.ToString()); // ok
+
+        box.Value = value; // ok
+        Console.WriteLine(box.Value.ToString()); // ok
+
+       if (box.Value == null) {
+            Console.WriteLine(box.Value.ToString()); // warning
+        }
     }
 }
 ```


### PR DESCRIPTION
We may find that some of these samples are not actually useful. It feels like it depends on exactly what the generic property's purpose is. The most common scenario I know for "null-accepting" properties is strings which replace `null` with `string.Empty`.